### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-swagger-codegen-maven-plugin
+swagger-codegen-gradle-plugin
 ============================
 
 [![Build Status](https://travis-ci.org/thebignet/swagger-codegen-gradle-plugin.svg?branch=master)](https://travis-ci.org/thebignet/swagger-codegen-gradle-plugin)


### PR DESCRIPTION
swagger-codegen-maven-plugin => swagger-codegen-gradle-plugin

You should also change your GitHub repo's description (tagline, the paragraph that appears on top) - it still says "A Maven plugin to support the swagger code generation project" too.
