### PR TITLE
README with link to swagger-codegen-gradle-plugin-example

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A Gradle plugin to support the [swagger](http://swagger.io) code generation proj
 Usage
 ============================
 
+see the [swagger-codegen-gradle-plugin-example](https://github.com/vorburger/swagger-codegen-gradle-plugin-example), or:
+
 Add to your `build.gradle` the following
 ```groovy
 ext {


### PR DESCRIPTION
hi @thebignet - I've created an swagger-codegen-gradle-plugin-example, perhaps you could link to it via this PR? I'm having some Gradle related trouble in swagger-codegen-gradle-plugin-example, if you know how to fix the TODO in my https://github.com/vorburger/swagger-codegen-gradle-plugin-example/blob/master/README.md that would be cool, and perhaps useful to others as well.
