### PR TITLE
Updated swagger-codegen to version 2.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ apply plugin: 'maven'
 
 dependencies {
     testCompile 'junit:junit:4.12'
-    compile 'io.swagger:swagger-codegen:2.2.0'
+    compile 'io.swagger:swagger-codegen:2.2.1'
     compile gradleApi()
     compile localGroovy()
 }


### PR DESCRIPTION
Updating the codegen version as the Scalatra language has a bug in 2.2.0 that was fixed in 2.2.1 which prevents me from using this plugin.
